### PR TITLE
fix to make tests run with 'python setup.py test'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ class PyTest(TestCommand):
     def finalize_options(self):
         TestCommand.finalize_options(self)
         self.test_suite = True
+        self.test_args = []
 
     def run_tests(self):
         import pytest


### PR DESCRIPTION
This is the result of "python setup.py test" before applying this fix.

    $ python setup.py test
    running test
    Traceback (most recent call last):
      File "setup.py", line 57, in <module>
        'Topic :: Utilities',
      File "/usr/lib/python2.7/distutils/core.py", line 151, in setup
        dist.run_commands()
      File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
        self.run_command(cmd)
      File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
        cmd_obj.run()
      File "/usr/lib/python2.7/dist-packages/setuptools/command/test.py", line 141, in run
        cmd = ' '.join(self._argv)
    TypeError: sequence item 2: expected string, bool found
    $ 
