### PR TITLE
cert duration: set default duration to 3 years, due to new 39-month max

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ os:
 sudo: false
 
 install:
+  - pip install -U pip setuptools
   - python setup.py install
   - pip install coverage pytest-cov coveralls
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,8 @@ environment:
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python34-x64"
     - PYTHON: "C:\\Python35"
-    - PYTHON: "C:\\Python36-x64"
-    - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python36-x64"
 
 install:        

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,32 @@
+environment:
+  global:
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
+
+  matrix:
+    - PYTHON: "C:\\Python26"
+    - PYTHON: "C:\\Python26-x64"
+    - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python27-x64"
+    - PYTHON: "C:\\Python33"
+    - PYTHON: "C:\\Python33-x64"
+    - PYTHON: "C:\\Python34"
+    - PYTHON: "C:\\Python34-x64"
+    - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python36-x64"
+
+install:        
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - "pip install --disable-pip-version-check --user --upgrade pip"
+  - "pip install -U setuptools"
+  - "pip install pyopenssl"
+  - "pip install coverage pytest-cov coveralls"
+
+build_script:
+  - "python setup.py install"
+
+test_script:
+  - "python setup.py test"
+
+

--- a/certauth/certauth.py
+++ b/certauth/certauth.py
@@ -9,8 +9,10 @@ from argparse import ArgumentParser
 
 
 # =================================================================
-# Duration of 10 years
-CERT_DURATION = 10 * 365 * 24 * 60 * 60
+# Duration of 3 years
+# Max vailidity is 39 months:
+# https://casecurity.org/2015/02/19/ssl-certificate-validity-periods-limited-to-39-months-starting-in-april/
+CERT_DURATION = 3 * 365 * 24 * 60 * 60
 
 CERTS_DIR = './ca/certs/'
 
@@ -32,7 +34,10 @@ class CertificateAuthority(object):
     """
 
     def __init__(self, ca_file, certs_dir, ca_name,
-                 overwrite=False):
+                 overwrite=False,
+                 cert_start=0,
+                 cert_duration=CERT_DURATION):
+
         assert(ca_file)
         self.ca_file = ca_file
 
@@ -43,6 +48,9 @@ class CertificateAuthority(object):
         self.ca_name = ca_name
 
         self._file_created = False
+
+        self.cert_start = cert_start
+        self.cert_duration = cert_duration
 
         if not os.path.exists(certs_dir):
             os.makedirs(certs_dir)
@@ -86,25 +94,23 @@ class CertificateAuthority(object):
         p12.set_privatekey(self.key)
         return p12.export()
 
-    @staticmethod
-    def _make_cert(certname):
+    def _make_cert(self, certname):
         cert = crypto.X509()
         cert.set_serial_number(random.randint(0, 2 ** 64 - 1))
         cert.get_subject().CN = certname
 
         cert.set_version(2)
-        cert.gmtime_adj_notBefore(0)
-        cert.gmtime_adj_notAfter(CERT_DURATION)
+        cert.gmtime_adj_notBefore(self.cert_start)
+        cert.gmtime_adj_notAfter(self.cert_duration)
         return cert
 
-    @staticmethod
-    def generate_ca_root(ca_file, ca_name, hash_func=DEF_HASH_FUNC):
+    def generate_ca_root(self, ca_file, ca_name, hash_func=DEF_HASH_FUNC):
         # Generate key
         key = crypto.PKey()
         key.generate_key(crypto.TYPE_RSA, 2048)
 
         # Generate cert
-        cert = CertificateAuthority._make_cert(ca_name)
+        cert = self._make_cert(ca_name)
 
         cert.set_issuer(cert.get_subject())
         cert.set_pubkey(key)
@@ -125,11 +131,10 @@ class CertificateAuthority(object):
         cert.sign(key, hash_func)
 
         # Write cert + key
-        CertificateAuthority.write_pem(ca_file, cert, key)
+        self.write_pem(ca_file, cert, key)
         return cert, key
 
-    @staticmethod
-    def generate_host_cert(host, root_cert, root_key, host_filename,
+    def generate_host_cert(self, host, root_cert, root_key, host_filename,
                            wildcard=False, hash_func=DEF_HASH_FUNC):
 
         host = host.encode('utf-8')
@@ -145,7 +150,7 @@ class CertificateAuthority(object):
         req.sign(key, hash_func)
 
         # Generate Cert
-        cert = CertificateAuthority._make_cert(host)
+        cert = self._make_cert(host)
 
         cert.set_issuer(root_cert.get_subject())
         cert.set_pubkey(req.get_pubkey())
@@ -165,18 +170,16 @@ class CertificateAuthority(object):
         cert.sign(root_key, hash_func)
 
         # Write cert + key
-        CertificateAuthority.write_pem(host_filename, cert, key)
+        self.write_pem(host_filename, cert, key)
         return cert, key
 
-    @staticmethod
-    def write_pem(filename, cert, key):
+    def write_pem(self, filename, cert, key):
         with open(filename, 'wb+') as f:
             f.write(crypto.dump_privatekey(FILETYPE_PEM, key))
 
             f.write(crypto.dump_certificate(FILETYPE_PEM, cert))
 
-    @staticmethod
-    def read_pem(filename):
+    def read_pem(self, filename):
         with open(filename, 'r') as f:
             cert = crypto.load_certificate(FILETYPE_PEM, f.read())
             f.seek(0)

--- a/certauth/certauth.py
+++ b/certauth/certauth.py
@@ -9,10 +9,10 @@ from argparse import ArgumentParser
 
 
 # =================================================================
-# Duration of 3 years
-# Max vailidity is 39 months:
+# Valid for 3 years from now
+# Max validity is 39 months:
 # https://casecurity.org/2015/02/19/ssl-certificate-validity-periods-limited-to-39-months-starting-in-april/
-CERT_DURATION = 3 * 365 * 24 * 60 * 60
+CERT_NOT_AFTER = 3 * 365 * 24 * 60 * 60
 
 CERTS_DIR = './ca/certs/'
 
@@ -35,8 +35,8 @@ class CertificateAuthority(object):
 
     def __init__(self, ca_file, certs_dir, ca_name,
                  overwrite=False,
-                 cert_start=0,
-                 cert_duration=CERT_DURATION):
+                 cert_not_before=0,
+                 cert_not_after=CERT_NOT_AFTER):
 
         assert(ca_file)
         self.ca_file = ca_file
@@ -49,8 +49,8 @@ class CertificateAuthority(object):
 
         self._file_created = False
 
-        self.cert_start = cert_start
-        self.cert_duration = cert_duration
+        self.cert_not_before = cert_not_before
+        self.cert_not_after = cert_not_after
 
         if not os.path.exists(certs_dir):
             os.makedirs(certs_dir)
@@ -100,8 +100,8 @@ class CertificateAuthority(object):
         cert.get_subject().CN = certname
 
         cert.set_version(2)
-        cert.gmtime_adj_notBefore(self.cert_start)
-        cert.gmtime_adj_notAfter(self.cert_duration)
+        cert.gmtime_adj_notBefore(self.cert_not_before)
+        cert.gmtime_adj_notAfter(self.cert_not_after)
         return cert
 
     def generate_ca_root(self, ca_file, ca_name, hash_func=DEF_HASH_FUNC):

--- a/setup.py
+++ b/setup.py
@@ -14,13 +14,13 @@ class PyTest(TestCommand):
         import pytest
         import sys
         import os
-        cmdline = ' --cov certauth -v test/'
-        errcode = pytest.main(cmdline)
+        cmdline = '--cov certauth -v test/'
+        errcode = pytest.main(cmdline.split(' '))
         sys.exit(errcode)
 
 setup(
     name='certauth',
-    version='1.1.4',
+    version='1.1.5',
     author='Ilya Kreymer',
     author_email='ikreymer@gmail.com',
     license='MIT',
@@ -46,7 +46,7 @@ setup(
         'pytest-cov',
     ],
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2.6',

--- a/test/test_certauth.py
+++ b/test/test_certauth.py
@@ -61,7 +61,9 @@ def test_create_root_subdir():
 
     ca_file = os.path.join(subdir, 'certauth_test_ca.pem')
 
-    ca = CertificateAuthority(ca_file, subdir, 'Test CA')
+    ca = CertificateAuthority(ca_file, subdir, 'Test CA',
+                             cert_start=-60 * 60,
+                             cert_duration=60 * 60 * 24 * 3)
 
     assert os.path.isdir(subdir)
     assert os.path.isfile(ca_file)

--- a/test/test_certauth.py
+++ b/test/test_certauth.py
@@ -5,6 +5,7 @@ from certauth.certauth import main, CertificateAuthority
 import tempfile
 from OpenSSL import crypto
 import datetime
+import time
 
 def setup_module():
     global TEST_CA_DIR
@@ -83,6 +84,7 @@ def test_create_root_subdir():
     actual_not_after = datetime.datetime.strptime(
             cert.get_notAfter().decode('ascii'), '%Y%m%d%H%M%SZ')
 
-    assert abs((actual_not_before.timestamp() - expected_not_before.timestamp())) < 10
-    assert abs((actual_not_after.timestamp() - expected_not_after.timestamp())) < 10
+    time.mktime(expected_not_before.utctimetuple())
+    assert abs((time.mktime(actual_not_before.utctimetuple()) - time.mktime(expected_not_before.utctimetuple()))) < 10
+    assert abs((time.mktime(actual_not_after.utctimetuple()) - time.mktime(expected_not_after.utctimetuple()))) < 10
 

--- a/test/test_certauth.py
+++ b/test/test_certauth.py
@@ -64,8 +64,8 @@ def test_create_root_subdir():
     ca_file = os.path.join(subdir, 'certauth_test_ca.pem')
 
     ca = CertificateAuthority(ca_file, subdir, 'Test CA',
-                             cert_start=-60 * 60,
-                             cert_duration=60 * 60 * 24 * 3)
+                              cert_not_before=-60 * 60,
+                              cert_not_after=60 * 60 * 24 * 3)
 
     assert os.path.isdir(subdir)
     assert os.path.isfile(ca_file)
@@ -74,7 +74,7 @@ def test_create_root_subdir():
     assert len(buff) > 0
 
     expected_not_before = datetime.datetime.utcnow() - datetime.timedelta(seconds=60 * 60)
-    expected_not_after = expected_not_before + datetime.timedelta(seconds=60 * 60 * 24 * 3)
+    expected_not_after = datetime.datetime.utcnow() + datetime.timedelta(seconds=60 * 60 * 24 * 3)
 
     cert = crypto.load_pkcs12(buff).get_certificate()
 

--- a/test/test_certauth.py
+++ b/test/test_certauth.py
@@ -83,6 +83,6 @@ def test_create_root_subdir():
     actual_not_after = datetime.datetime.strptime(
             cert.get_notAfter().decode('ascii'), '%Y%m%d%H%M%SZ')
 
-    assert abs((actual_not_before - expected_not_before).total_seconds()) < 10
-    assert abs((actual_not_after - expected_not_after).total_seconds()) < 10
+    assert abs((actual_not_before.timestamp() - expected_not_before.timestamp())) < 10
+    assert abs((actual_not_after.timestamp() - expected_not_after.timestamp())) < 10
 


### PR DESCRIPTION
add cert_start and cert_duration times as optional params to CertificateAuthority
CertificateAuthority: convert static methods to members for easier customization
fix pytest warning
bump to 1.1.5, update trove to stable!