### PR TITLE
Fix empty dir in root ca filename

### DIFF
--- a/certauth/certauth.py
+++ b/certauth/certauth.py
@@ -286,8 +286,8 @@ class FileCache(object):
         self.certs_dir = certs_dir
         self.modified = False
 
-        if not os.path.exists(certs_dir):
-            os.makedirs(certs_dir)
+        if self.certs_dir and not os.path.exists(self.certs_dir):
+            os.makedirs(self.certs_dir)
 
     def key_for_host(self, host):
         host = host.replace(':', '-')
@@ -313,7 +313,7 @@ class FileCache(object):
 class RootCACache(FileCache):
     def __init__(self, ca_file):
         self.ca_file = ca_file
-        ca_dir = os.path.dirname(ca_file)
+        ca_dir = os.path.dirname(ca_file) or '.'
         super(RootCACache, self).__init__(ca_dir)
 
     def key_for_host(self, host=None):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ class PyTest(TestCommand):
 
 setup(
     name='certauth',
-    version='1.2.1',
+    version='1.2.2',
     author='Ilya Kreymer',
     author_email='ikreymer@gmail.com',
     license='MIT',

--- a/test/test_certauth.py
+++ b/test/test_certauth.py
@@ -12,6 +12,9 @@ import time
 import pytest
 
 
+CA_ROOT_FILENAME = 'certauth_test_ca.pem'
+
+
 @pytest.fixture
 def ca():
     return CertificateAuthority('Test CA', TEST_CA_ROOT, TEST_CA_DIR)
@@ -21,10 +24,16 @@ def setup_module():
     global TEST_CA_DIR
     TEST_CA_DIR = tempfile.mkdtemp()
 
+    global orig_cwd
+    orig_cwd = os.getcwd()
+    os.chdir(TEST_CA_DIR)
+
     global TEST_CA_ROOT
-    TEST_CA_ROOT = os.path.join(TEST_CA_DIR, 'certauth_test_ca.pem')
+    TEST_CA_ROOT = os.path.join(TEST_CA_DIR, CA_ROOT_FILENAME)
 
 def teardown_module():
+    os.chdir(orig_cwd)
+
     shutil.rmtree(TEST_CA_DIR)
     assert not os.path.isdir(TEST_CA_DIR)
     assert not os.path.isfile(TEST_CA_ROOT)
@@ -247,4 +256,8 @@ def test_ca_lru_cache():
 
     assert 'example.com' not in lru
 
+
+def test_create_root_no_dir_already_exists():
+    ret = main([CA_ROOT_FILENAME, '-c', 'Test Root Cert'])
+    assert ret == 1
 


### PR DESCRIPTION
Default to `.` as directory and also don't `makedirs` on empty directory, fixes #10 