### PR TITLE
Add TLD Check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
 

--- a/README.rst
+++ b/README.rst
@@ -98,6 +98,12 @@ To automatically generate a wildcard cert for parent domain, use:
 
 This will also generate a cert for ``*.example.com``
 
+Starting with 1.3.0, ``certauth`` uses ``tldextract`` to determine the tld for a given host,
+and will not use a parent domain if it is itself a tld suffix.
+
+For example, calling ``load_cert`` with ``wildcard_for_parent=True`` applied to ``example.co.uk`` will generate a cert
+for ``*.example.co.uk`` not ``*.co.uk``.
+
 
 CLI Usage Examples
 ==================

--- a/README.rst
+++ b/README.rst
@@ -101,8 +101,13 @@ This will also generate a cert for ``*.example.com``
 Starting with 1.3.0, ``certauth`` uses ``tldextract`` to determine the tld for a given host,
 and will not use a parent domain if it is itself a tld suffix.
 
-For example, calling ``load_cert`` with ``wildcard_for_parent=True`` applied to ``example.co.uk`` will generate a cert
-for ``*.example.co.uk`` not ``*.co.uk``.
+For example, calling:
+
+.. code:: python
+
+   cert, key = ca.load_cert('example.co.uk', wildcard=True, wildcard_for_parent=True)
+   
+will now result in a cert for ``*.example.co.uk``, not ``*.co.uk``.
 
 
 CLI Usage Examples

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,6 @@ environment:
   matrix:
     - PYTHON: "C:\\Python27"
     - PYTHON: "C:\\Python27-x64"
-    - PYTHON: "C:\\Python34"
-    - PYTHON: "C:\\Python34-x64"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36"

--- a/certauth/certauth.py
+++ b/certauth/certauth.py
@@ -33,11 +33,6 @@ ROOT_CA = '!!root_ca'
 
 
 # =================================================================
-# don't auto-update suffix list
-tld = tldextract.TLDExtract(suffix_list_urls=None)
-
-
-# =================================================================
 class CertificateAuthority(object):
     """
     Utility class for signing individual certificate
@@ -117,7 +112,7 @@ class CertificateAuthority(object):
         if len(host_parts) < 2 or '.' not in host_parts[1]:
             return host
 
-        ext = tld(host)
+        ext = tldextract.extract(host)
 
         # allow using parent domain if:
         # 1) no suffix (unknown tld)

--- a/certauth/certauth.py
+++ b/certauth/certauth.py
@@ -107,7 +107,7 @@ class CertificateAuthority(object):
         except (ValueError, UnicodeDecodeError) as e:
             return False
 
-    def get_parent_domain(self, host):
+    def get_wildcard_domain(self, host):
         host_parts = host.split('.', 1)
         if len(host_parts) < 2 or '.' not in host_parts[1]:
             return host
@@ -133,7 +133,7 @@ class CertificateAuthority(object):
             wildcard = False
 
         if wildcard and wildcard_use_parent:
-            host = self.get_parent_domain(host)
+            host = self.get_wildcard_domain(host)
 
         cert_str = None
 

--- a/certauth/certauth.py
+++ b/certauth/certauth.py
@@ -9,6 +9,7 @@ from OpenSSL.SSL import FILETYPE_PEM
 import random
 
 import ipaddress
+import tldextract
 
 from argparse import ArgumentParser
 
@@ -29,6 +30,11 @@ CERT_NAME = 'certauth sample CA'
 DEF_HASH_FUNC = 'sha256'
 
 ROOT_CA = '!!root_ca'
+
+
+# =================================================================
+# don't auto-update suffix list
+tld = tldextract.TLDExtract(suffix_list_urls=None)
 
 
 # =================================================================
@@ -106,6 +112,21 @@ class CertificateAuthority(object):
         except (ValueError, UnicodeDecodeError) as e:
             return False
 
+    def get_parent_domain(self, host):
+        host_parts = host.split('.', 1)
+        if len(host_parts) < 2 or '.' not in host_parts[1]:
+            return host
+
+        ext = tld(host)
+
+        # allow using parent domain if:
+        # 1) no suffix (unknown tld)
+        # 2) the parent domain contains 'domain.suffix', not just .suffix
+        if not ext.suffix or ext.domain + '.' + ext.suffix in host_parts[1]:
+            return host_parts[1]
+
+        return host
+
     def load_cert(self, host, overwrite=False,
                               wildcard=False,
                               wildcard_use_parent=False,
@@ -117,9 +138,7 @@ class CertificateAuthority(object):
             wildcard = False
 
         if wildcard and wildcard_use_parent:
-            host_parts = host.split('.', 1)
-            if len(host_parts) == 2 and '.' in host_parts[1]:
-                host = host_parts[1]
+            host = self.get_parent_domain(host)
 
         cert_str = None
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ class PyTest(TestCommand):
 
 setup(
     name='certauth',
-    version='1.2.3',
+    version='1.3.0',
     author='Ilya Kreymer',
     author_email='ikreymer@gmail.com',
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ class PyTest(TestCommand):
 
 setup(
     name='certauth',
-    version='1.2.2',
+    version='1.2.3',
     author='Ilya Kreymer',
     author_email='ikreymer@gmail.com',
     license='MIT',
@@ -33,6 +33,7 @@ setup(
         ],
     install_requires=[
         'pyopenssl',
+        'tldextract',
         ],
     zip_safe=True,
     entry_points="""

--- a/test/test_certauth.py
+++ b/test/test_certauth.py
@@ -165,6 +165,32 @@ def test_in_mem_parent_wildcard_cert():
 
     verify_cert_san(cert2, 'DNS:example.proxy, DNS:*.example.proxy')
 
+def test_in_mem_parent_wildcard_cert_at_tld():
+    cert_cache = {}
+    ca = CertificateAuthority('Test CA', TEST_CA_ROOT, cert_cache)
+    cert, key = ca.load_cert('example.org.uk', wildcard=True, wildcard_use_parent=True)
+    assert 'example.org.uk' in cert_cache, cert_cache.keys()
+
+    cached_value = cert_cache['example.org.uk']
+    cert2, key2 = ca.load_cert('example.org.uk')
+    # assert underlying cache unchanged
+    assert cached_value == cert_cache['example.org.uk']
+
+    verify_cert_san(cert2, 'DNS:example.org.uk, DNS:*.example.org.uk')
+
+def test_in_mem_parent_wildcard_cert_2():
+    cert_cache = {}
+    ca = CertificateAuthority('Test CA', TEST_CA_ROOT, cert_cache)
+    cert, key = ca.load_cert('test.example.org.uk', wildcard=True, wildcard_use_parent=True)
+    assert 'example.org.uk' in cert_cache, cert_cache.keys()
+
+    cached_value = cert_cache['example.org.uk']
+    cert2, key2 = ca.load_cert('example.org.uk')
+    # assert underlying cache unchanged
+    assert cached_value == cert_cache['example.org.uk']
+
+    verify_cert_san(cert2, 'DNS:example.org.uk, DNS:*.example.org.uk')
+
 def test_create_root_already_exists():
     ret = main([TEST_CA_ROOT])
     # not created, already exists


### PR DESCRIPTION
When using the `wildcard_for_parent` option, ensure that the parent domain is not a tld suffix, otherwise generate cert for current domain.