### PR TITLE
Allow alternative SAN ips and FQDNs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,6 +110,21 @@ For example, calling:
 will now result in a cert for ``*.example.co.uk``, not ``*.co.uk``.
 
 
+Alternative FQDNs or IPs in SAN
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sometimes, you want to add alternative FQDNs or IPs as Subject Alternative Names
+to your certificate. To do that, simply use the ``cert_fqdns`` or ``cert_ips``
+params of ``load_cert``:
+
+.. code:: python
+
+   cert, key = ca.load_cert('example.com', cert_fqdns=['example.org'], cert_ips=['192.168.1.1'])
+
+This will generate a cert for ``example.com`` with ``example.org`` and ``192.168.1.1`` in
+the SAN.
+
+
 CLI Usage Examples
 ==================
 


### PR DESCRIPTION
Hi,
Thanks for your lib.

This commit allows the creation of certificates with alternative IPs or FQDNs in the SAN.

The `verify_san` method was modified in order to accept a list instead of a string, making tests easier (the SAN field is not order sensitive).

Cheers,