### PR TITLE
Valid time update

### DIFF
--- a/certauth/certauth.py
+++ b/certauth/certauth.py
@@ -21,7 +21,7 @@ import threading
 # Valid for 2 years from now
 # Max validity is 24 months:
 # https://cabforum.org/2017/03/17/ballot-193-825-day-certificate-lifetimes/
-CERT_NOT_AFTER = 3 * 365 * 24 * 60 * 60
+CERT_NOT_AFTER = 2 * 365 * 24 * 60 * 60
 
 CERTS_DIR = './ca/certs/'
 

--- a/certauth/certauth.py
+++ b/certauth/certauth.py
@@ -18,9 +18,9 @@ from collections import OrderedDict
 import threading
 
 # =================================================================
-# Valid for 3 years from now
-# Max validity is 39 months:
-# https://casecurity.org/2015/02/19/ssl-certificate-validity-periods-limited-to-39-months-starting-in-april/
+# Valid for 2 years from now
+# Max validity is 24 months:
+# https://cabforum.org/2017/03/17/ballot-193-825-day-certificate-lifetimes/
 CERT_NOT_AFTER = 3 * 365 * 24 * 60 * 60
 
 CERTS_DIR = './ca/certs/'


### PR DESCRIPTION
Certificate validity times were updated (again) on March 1, 2018. I've updated the code to reflect this.